### PR TITLE
Better Kernel Version condition for REGULATORY_IGNORE_STALE_KICKOFF m…

### DIFF
--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -405,7 +405,7 @@ int rtw_regd_init(struct wiphy *wiphy)
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 39))
 	return 0;	
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;


### PR DESCRIPTION
…issing define

REGULATORY_IGNORE_STALE_KICKOFF is deprecated since 6.1.39 see commit 132b7129c5fe90197d2581dd5e786542f9a09d86 in mainline kernel